### PR TITLE
Add support to connect all compatible terra extensions in window scope

### DIFF
--- a/src/layouts/ConnectList.tsx
+++ b/src/layouts/ConnectList.tsx
@@ -10,7 +10,12 @@ const ConnectList = () => {
   const { availableConnectTypes, availableInstallTypes, connect, install } =
     useWallet()
 
+  // Terra.js injects the compatible wallet extensions into the window object.
+  // We can use this to detect and display any terra extensions in the scope.
+  const walletExtensions = window.terraWallets ?? []
+
   type Button = { label: string; image: ReactNode; onClick: () => void }
+
   const buttons = ([] as Button[])
     .concat(
       availableInstallTypes.includes(ConnectType.EXTENSION)
@@ -22,19 +27,11 @@ const ConnectList = () => {
         : []
     )
     .concat(
-      availableConnectTypes.includes(ConnectType.EXTENSION)
-        ? {
-            label: "Terra Station Extension",
-            image: <Terra {...size} />,
-            onClick: () => connect(ConnectType.EXTENSION),
-          }
-        : availableConnectTypes.includes(ConnectType.EXTENSION)
-        ? {
-            label: "Terra Station Extension",
-            image: <Terra {...size} />,
-            onClick: () => connect(ConnectType.EXTENSION),
-          }
-        : []
+      walletExtensions.map((wallet) => ({
+        label: wallet.name,
+        image: <img src={wallet.icon} {...size} alt={wallet.name} />,
+        onClick: () => connect(ConnectType.EXTENSION, wallet.identifier),
+      }))
     )
     .concat(
       availableConnectTypes.includes(ConnectType.WALLETCONNECT)


### PR DESCRIPTION
This PR adds support to detect all compatible terra extensions in the browser window scope, and to connect with them using terra wallet provider. This makes sure that Leap wallet is also supported on Mirror dapp. As you can see in the demo video below:

Case 1: No terra extensions are installed

Case 2: Leap Wallet is installed

Case 3: Terra Station is installed

Case 4: Both Terra Station and Leap Wallet are installed.

https://user-images.githubusercontent.com/93123418/150304544-7b0d3da7-f9ac-4674-8d0c-a37473fd4296.mp4

